### PR TITLE
Command menu wording inconsistent

### DIFF
--- a/cmd/kubevent/root.go
+++ b/cmd/kubevent/root.go
@@ -23,7 +23,7 @@ func NewRootCmd() *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().StringVar(&logLevel, "log_level", logrus.InfoLevel.String(), "Log level")
+	cmd.PersistentFlags().StringVar(&logLevel, "loglevel", logrus.InfoLevel.String(), "log level")
 
 	cmd.AddCommand(
 		NewServerCmd(),

--- a/cmd/kubevent/schema.go
+++ b/cmd/kubevent/schema.go
@@ -7,7 +7,7 @@ import (
 func NewSchemaCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "schema",
-		Short: "schema, show cluster API resources info",
+		Short: "Schema, show cluster API resources info",
 		Run: func(cmd *cobra.Command, args []string) {
 			for _, t := range scheme.AllKnownTypes() {
 				println(t.String())

--- a/cmd/kubevent/server.go
+++ b/cmd/kubevent/server.go
@@ -23,7 +23,7 @@ func init() {
 func NewServerCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "server",
-		Short: "server, run event broker controller",
+		Short: "Server, run event broker controller",
 		Run: func(cmd *cobra.Command, args []string) {
 			logrus.Infoln("creating event broker controller manager")
 


### PR DESCRIPTION
**Before**
```
Usage:
  kubevent [command]

Available Commands:
  help        Help about any command
  schema      schema, show cluster API resources info
  server      server, run event broker controller
  version     Show version

Flags:
  -h, --help              help for kubevent
      --log_level string   Log level (default "info")
```
**After**
```
Usage:
  kubevent [command]

Available Commands:
  help        Help about any command
  schema      Schema, show cluster API resources info
  server      Server, run event broker controller
  version     Show version

Flags:
  -h, --help              help for kubevent
      --loglevel string   log level (default "info")
```

Signed-off-by: Chin-Ya Huang <chin-ya.huang@suse.com>